### PR TITLE
add return type for invoke(instances.create)

### DIFF
--- a/lib/zendesk_types/support_apps/common.ts
+++ b/lib/zendesk_types/support_apps/common.ts
@@ -11,19 +11,24 @@ export type Create = (newInstance: {
     location: string
     url: string
     size?: { width: string; height: string }
-}) => any[]
+}) => {
+    errors: any
+    "instances.create": Instance[]
+}
+
+export type Instance = {
+    instanceGuid: string
+    host: string
+    product: string
+    location: string
+    account: {
+        subdomain: string
+    }
+    status: string
+}
 
 export type Instances = {
-    [instanceGuid: string]: {
-        instanceGuid: string
-        host: string
-        product: string
-        location: string
-        account: {
-            subdomain: string
-        }
-        status: string
-    }
+    [instanceGuid: string]: Instance
 }
 
 // Objects


### PR DESCRIPTION
Hi,

first off: thanks a lot for creating this, I've been wanting to write something similar for a long time but never got around to it. I'll try to contribute where I can.

I noticed that the result for `client.invoke(Core.Actions.instances.create), {...})` was typed as `any[]`, when in reality it looks like this:

```js
{
  "errors": {},
  "instances.create": [
    {
      "host": "zendesk",
      "product": "support",
      "location": "modal",
      "instanceGuid": "56a969a5-826c-4989-8be7-9cea6eb1e4d4",
      "account": {
        "subdomain": "[readcated]"
      },
      "status": "created"
    }
  ]
}
```

I attached my proposed remedy, reusing the extracted type from the `Instances` property.

Hope you find this useful, looking forward to your comments, keen to make any required changes to get this marged.