### PR TITLE
fix: use correct types for metadata and context

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -3,6 +3,7 @@ import {
     Dimension,
     Create,
     Instances,
+    AppRegistrationData,
 } from "./zendesk_types/support_apps/common"
 
 export namespace Core {
@@ -49,7 +50,7 @@ export namespace Core {
 
     export namespace Events {
         export namespace app {
-            export const registered: ZendeskEvent<(data: any) => any> = {
+            export const registered: ZendeskEvent<(data: AppRegistrationData) => void> = {
                 _path: "app.registered",
             }
             export const activated: ZendeskEvent<(data: any) => any> = {

--- a/lib/reified_client.ts
+++ b/lib/reified_client.ts
@@ -5,7 +5,7 @@ import {
     ZendeskWritableProperty,
     ZendeskAction,
 } from "./wrapper_types"
-import { MetaData } from "./zendesk_types/support_apps/common"
+import { Context, MetaData } from "./zendesk_types/support_apps/common"
 import { Client, ClientRequestOptions } from "./zendesk_types/zaf_sdk"
 
 export class ReifiedClient {
@@ -15,7 +15,7 @@ export class ReifiedClient {
         this.zafClient = client
     }
 
-    async context(): Promise<any> {
+    async context(): Promise<Context> {
         return await this.zafClient.context()
     }
 
@@ -32,7 +32,7 @@ export class ReifiedClient {
     }
 
     async metadata(): Promise<MetaData> {
-        return (await this.zafClient.metadata()) as MetaData
+        return await this.zafClient.metadata()
     }
 
     on<T>(event: ZendeskEvent<T>, handler: T): void {

--- a/lib/zendesk_types/support_apps/common.ts
+++ b/lib/zendesk_types/support_apps/common.ts
@@ -91,7 +91,7 @@ export interface AppsTray {
     hide(): { "appsTray.isVisible": false }
 }
 
-export interface MetaData {
+export interface Context {
     readonly instanceGuid: string
     readonly product: string
     readonly account: {
@@ -99,6 +99,16 @@ export interface MetaData {
     }
     readonly location: string
     readonly ticketId: number
+}
+
+export interface MetaData {
+    readonly appId: string
+    readonly name?: string
+    readonly installationId: string
+    readonly settings: Record<string, string>
+    readonly version: string
+    readonly stripe_subscription_id?: string
+    readonly plan?: Record<string, string>
 }
 
 // Addition Properties

--- a/lib/zendesk_types/support_apps/common.ts
+++ b/lib/zendesk_types/support_apps/common.ts
@@ -99,6 +99,7 @@ export interface Context {
     }
     readonly location: string
     readonly ticketId: number
+    readonly host: string
 }
 
 export interface MetaData {
@@ -109,6 +110,12 @@ export interface MetaData {
     readonly version: string
     readonly stripe_subscription_id?: string
     readonly plan?: Record<string, string>
+}
+
+export interface AppRegistrationData {
+  context: Context,
+  metadata: MetaData,
+  iframe_session_timeout: number
 }
 
 // Addition Properties

--- a/lib/zendesk_types/zaf_sdk.ts
+++ b/lib/zendesk_types/zaf_sdk.ts
@@ -1,9 +1,11 @@
+import { Context, MetaData } from "./support_apps/common"
+
 export declare class Client {
     /**
      * Requests context for the app, such as the host and location. Depending on the location, the context may provide additional identifiers that you can use with the REST API to request additional data.
      * @returns {any} A JavaScript Promise any.
      */
-    context(): Promise<any>
+    context(): Promise<Context>
     /**
      * Gets data from the UI asynchronously. For a complete list of supported paths, see:
      *
@@ -55,7 +57,7 @@ export declare class Client {
      * Requests metadata for the app, such as the app id, installation id, app plan information, and Stripe subscription id (if applicable).
      * @returns {Promise<any>} A JavaScript Promise object.
      */
-    metadata(): Promise<any>
+    metadata(): Promise<MetaData>
     /**
      * Allows you to remove a handler for a framework event.
      * @param {string} name the name of the event


### PR DESCRIPTION
It looks like the type definitions for context() and metadata() have been mixed up. This PR corrects that.

This does conflict with #2 but I can easily rebase them.
There are more small corrections and nitpicks under way, I'll try to submit them one by one.

For reference, here are the respective sdk docs:

* [context](https://developer.zendesk.com/api-reference/apps/apps-core-api/client_api/#clientcontext)
* [metadata](https://developer.zendesk.com/api-reference/apps/apps-core-api/client_api/#clientmetadata)
