### PR TITLE
add types for client constructor

### DIFF
--- a/lib/zendesk_types/zaf_sdk.ts
+++ b/lib/zendesk_types/zaf_sdk.ts
@@ -1,4 +1,5 @@
 export declare class Client {
+    constructor(options?: ClientConstructorOptions)
     /**
      * Requests context for the app, such as the host and location. Depending on the location, the context may provide additional identifiers that you can use with the REST API to request additional data.
      * @returns {any} A JavaScript Promise any.
@@ -132,4 +133,9 @@ export interface ClientRequestOptions {
     type?: string
     url: string
     xhrFields?: any
+}
+
+export interface ClientConstructorOptions {
+    origin: string
+    appGuid: string
 }


### PR DESCRIPTION
I noticed that the ZAFClient constructor was missing types. This fixes that.