### PR TITLE
Fix event topbar deactivated

### DIFF
--- a/lib/support.ts
+++ b/lib/support.ts
@@ -2111,9 +2111,10 @@ export namespace Support {
                 > = {
                     _path: "pane.activated",
                 }
-                export const deactivatedactivated: ZendeskEvent<
+                export const deactivated: ZendeskEvent<
                     () => void | Promise<void>
                 > = { _path: "pane.deactivated" }
+                export const deactivatedactivated = deactivated // backwards compatibility
             }
         }
     }

--- a/main_test.test.ts
+++ b/main_test.test.ts
@@ -12,4 +12,8 @@ describe("Paths Test", () => {
     test("Indexable Path", () => {
         expect(Support.TicketSidebar.Objects.ticket.collaborators(4).identities(3).type._path).toBe("ticket.collaborators.4.identities.3.type")
     })
+    test("TopBar event pane deactivated", () => {
+        expect(Support.TopBar.Events.pane.deactivated._path).toBe("pane.deactivated")
+        expect(Support.TopBar.Events.pane.deactivatedactivated._path).toBe(Support.TopBar.Events.pane.deactivated._path)
+    }) 
 })


### PR DESCRIPTION
There appears to be a typo or some search-and-replace artifact in the TopBar event `pane.deactivated`, the exported constant is named Support.TopBar.Events.pane.`deactivatedactivated`.

This PR adds the correct spelling `Support.TopBar.Events.pane.deactivated` and adds an alias for backwards compatibility.